### PR TITLE
Offine baseline corrections; handle restarting the pipeline scripts

### DIFF
--- a/lband_pipeline/continuum_pipeline.py
+++ b/lband_pipeline/continuum_pipeline.py
@@ -17,7 +17,7 @@ from lband_pipeline.spw_setup import create_spw_dict
 
 # Handle runs where the internet query to the baseline correction site will
 # fail
-from lband_pipeline.offline_antposn_correction import make_offline_antpos_table
+from lband_pipeline.offline_antposn_corrections import make_offline_antpos_table
 
 
 # TODO: read in to skip a refant if needed.

--- a/lband_pipeline/continuum_pipeline.py
+++ b/lband_pipeline/continuum_pipeline.py
@@ -46,6 +46,9 @@ if len(context_files) > 0:
     # Will open the most recent context file
     context = h_resume()
 
+    casalog.post("Restarting from context {}".format(context))
+
+
     # Get pipeline call order:
     callorder = ['hifv_importdata',
                  'hifv_hanning',
@@ -86,14 +89,23 @@ if len(context_files) > 0:
 
         restart_stage = len(callorder) + 1
 
+        casalog.post("Calibration pipeline completed. Running QA plots only.")
+
+
     # Otherwise start from the next stage
     else:
         skip_pipeline = False
 
         restart_stage = len(callorder) + 1
 
+        casalog.post("Restarting at stage: {0} {1}".format(restart_stage, callorder[restart_stage]))
+
+
 # Otherwise this is a fresh run:
 else:
+
+    casalog.post("No context file found. Starting new pipeline run.")
+
     context = h_init()
 
     restart_stage = 0

--- a/lband_pipeline/continuum_pipeline.py
+++ b/lband_pipeline/continuum_pipeline.py
@@ -110,6 +110,8 @@ else:
 
     restart_stage = 0
 
+    skip_pipeline = False
+
 context.set_state('ProjectSummary', 'observatory',
                   'Karl G. Jansky Very Large Array')
 context.set_state('ProjectSummary', 'telescope', 'EVLA')

--- a/lband_pipeline/continuum_pipeline.py
+++ b/lband_pipeline/continuum_pipeline.py
@@ -14,6 +14,11 @@ from lband_pipeline.qa_plotting import (make_spw_bandpass_plots,
 # Info for SPW setup
 from lband_pipeline.spw_setup import create_spw_dict
 
+# Handle runs where the internet query to the baseline correction site will
+# fail
+from lband_pipeline.offline_antposn_correction import make_offline_antpos_table
+
+
 # TODO: read in to skip a refant if needed.
 refantignore = ""
 
@@ -68,6 +73,13 @@ try:
                   reffreq='1GHz')
 
     hifv_priorcals(tecmaps=False)
+
+    # Check offline tables (updated before each run) for antenna corrections
+    # If the online tables were accessed and the correction table already exists,
+    # skip remaking.
+    make_offline_antpos_table(myvis,
+                              data_folder="VLA_antcorr_tables",
+                              skip_existing=False)
 
     hifv_testBPdcals(weakbp=False)
 

--- a/lband_pipeline/continuum_pipeline.py
+++ b/lband_pipeline/continuum_pipeline.py
@@ -42,13 +42,11 @@ __rethrow_casa_exceptions = True
 # restart at last position:
 context_files = glob("pipeline*.context")
 if len(context_files) > 0:
-    context_files.sort()
 
-    context = context_files[-1]
+    # Will open the most recent context file
+    context = h_resume()
 
-    # Get pipeline calls:
-
-
+    # Get pipeline call order:
     callorder = ['hifv_importdata',
                  'hifv_hanning',
                  'hifv_flagdata',

--- a/lband_pipeline/line_pipeline.py
+++ b/lband_pipeline/line_pipeline.py
@@ -29,6 +29,9 @@ from lband_pipeline.target_setup import target_line_range_kms
 # For MW HI absorption flagging on calibrators:
 from lband_pipeline.calibrator_setup import calibrator_line_range_kms
 
+# Handle runs where the internet query to the baseline correction site will
+# fail
+from lband_pipeline.offline_antposn_correction import make_offline_antpos_table
 
 # TODO: read in to skip a refant if needed.
 refantignore = ""
@@ -113,6 +116,13 @@ try:
                   spix=0)
 
     hifv_priorcals(tecmaps=False)
+
+    # Check offline tables (updated before each run) for antenna corrections
+    # If the online tables were accessed and the correction table already exists,
+    # skip remaking.
+    make_offline_antpos_table(myvis,
+                              data_folder="VLA_antcorr_tables",
+                              skip_existing=False)
 
     hifv_testBPdcals(weakbp=False,
                      refantignore=refantignore)

--- a/lband_pipeline/line_pipeline.py
+++ b/lband_pipeline/line_pipeline.py
@@ -57,6 +57,7 @@ for spwid in linespw_dict:
 if hi_spw is None:
     raise ValueError("Unable to identify the HI SPW.")
 
+products_folder = "products"
 
 __rethrow_casa_exceptions = True
 
@@ -65,13 +66,11 @@ __rethrow_casa_exceptions = True
 # restart at last position:
 context_files = glob("pipeline*.context")
 if len(context_files) > 0:
-    context_files.sort()
 
-    context = context_files[-1]
+    # Will open the most recent context file
+    context = h_resume()
 
     # Get pipeline calls:
-
-
     callorder = ['hifv_importdata',
                  'hifv_flagdata',
                  'hifv_vlasetjy',
@@ -96,11 +95,40 @@ if len(context_files) > 0:
     # Get existing order to match with the call order:
     current_callorder = [result.read().pipeline_casa_task.split("(")[0] for result in context.results]
 
+    # Make sure the order is what we expect
+    matching_calls = np.array(current_callorder) == np.array(callorder[:len(current_callorder)])
+
+    if not matching_calls.all():
+        raise ValueError("Call order not expected for this script: Expected: {0}\nFound: {1}"
+                         .format(callorder[:len(current_callorder)], current_callorder))
+
+    # Do we just need to make additional QA plots?
+    # i.e. the calibration did finish
+    if len(current_callorder) == len(callorder):
+        skip_pipeline = True
+
+        restart_stage = len(callorder) + 1
+
+        casalog.post("Calibration pipeline completed. Running QA plots only.")
+
+
+    # Otherwise start from the next stage
+    else:
+        skip_pipeline = False
+
+        restart_stage = len(callorder) + 1
+
+        casalog.post("Restarting at stage: {0} {1}".format(restart_stage, callorder[restart_stage]))
+
 # Otherwise this is a fresh run:
 else:
+    casalog.post("No context file found. Starting new pipeline run.")
+
     context = h_init()
 
     restart_stage = 0
+
+    skip_pipeline = False
 
 context.set_state('ProjectSummary', 'observatory',
                   'Karl G. Jansky Very Large Array')
@@ -108,154 +136,177 @@ context.set_state('ProjectSummary', 'telescope', 'EVLA')
 context.set_state('ProjectSummary', 'proposal_code', proj_code)
 context.set_state('ProjectSummary', 'piname', 'Adam Leroy')
 
-try:
-    hifv_importdata(ocorr_mode='co',
-                    nocopy=False,
-                    vis=[myvis],
-                    createmms='automatic',
-                    asis='Receiver CalAtmosphere',
-                    overwrite=False)
+if skip_pipeline:
+    try:
 
-    flag_hi_foreground(myvis,
-                       calibrator_line_range_kms,
-                       hi_spw,
-                       cal_intents=["CALIBRATE*"],
-                       test_run=False,
-                       test_print=True)
+        if restart_stage == 0:
 
-    # Create cont.dat file based on the target name.
-    build_cont_dat(myvis,
-                   target_line_range_kms,
-                   line_freqs=linerest_dict_GHz,
-                   fields=[],  # Empty list == all target fields
-                   outfile="cont.dat",
-                   overwrite=False,
-                   append=False)
+            hifv_importdata(ocorr_mode='co',
+                            nocopy=False,
+                            vis=[myvis],
+                            createmms='automatic',
+                            asis='Receiver CalAtmosphere',
+                            overwrite=False)
 
-    # Hanning smoothing is turned off for spectral lines.
-    # hifv_hanning(pipelinemode="automatic")
+        if not os.path.exists("cont.dat"):
+            # Create cont.dat file based on the target name.
+            build_cont_dat(myvis,
+                        target_line_range_kms,
+                        line_freqs=linerest_dict_GHz,
+                        fields=[],  # Empty list == all target fields
+                        outfile="cont.dat",
+                        overwrite=False,
+                        append=False)
 
-    hifv_flagdata(intents='*POINTING*,*FOCUS*,*ATMOSPHERE*,*SIDEBAND_RATIO*, \
-                  *UNKNOWN*, *SYSTEM_CONFIGURATION*, \
-                  *UNSPECIFIED#UNSPECIFIED*',
-                  flagbackup=False,
-                  scan=True,
-                  baseband=True,
-                  clip=True,
-                  autocorr=True,
-                  hm_tbuff='1.5int',
-                  template=True,
-                  # TODO: ensure we consistently use the same filename
-                  filetemplate="additional_flagging.txt",
-                  online=False,
-                  tbuff=0.0,
-                  fracspw=0.05,
-                  shadow=True,
-                  quack=True,
-                  edgespw=True)
+        if restart_stage < 1:
+            flag_hi_foreground(myvis,
+                            calibrator_line_range_kms,
+                            hi_spw,
+                            cal_intents=["CALIBRATE*"],
+                            test_run=False,
+                            test_print=True)
 
-    hifv_vlasetjy(fluxdensity=-1,
-                  scalebychan=True,
-                  reffreq='1GHz',
-                  spix=0)
+            # Hanning smoothing is turned off for spectral lines.
+            # hifv_hanning(pipelinemode="automatic")
 
-    hifv_priorcals(tecmaps=False)
+            hifv_flagdata(intents='*POINTING*,*FOCUS*,*ATMOSPHERE*,*SIDEBAND_RATIO*, \
+                        *UNKNOWN*, *SYSTEM_CONFIGURATION*, \
+                        *UNSPECIFIED#UNSPECIFIED*',
+                        flagbackup=False,
+                        scan=True,
+                        baseband=True,
+                        clip=True,
+                        autocorr=True,
+                        hm_tbuff='1.5int',
+                        template=True,
+                        # TODO: ensure we consistently use the same filename
+                        filetemplate="additional_flagging.txt",
+                        online=False,
+                        tbuff=0.0,
+                        fracspw=0.05,
+                        shadow=True,
+                        quack=True,
+                        edgespw=True)
 
-    # Check offline tables (updated before each run) for antenna corrections
-    # If the online tables were accessed and the correction table already exists,
-    # skip remaking.
-    make_offline_antpos_table(myvis,
-                              data_folder="VLA_antcorr_tables",
-                              skip_existing=False)
+        if restart_stage < 2:
+            hifv_vlasetjy(fluxdensity=-1,
+                        scalebychan=True,
+                        reffreq='1GHz',
+                        spix=0)
 
-    hifv_testBPdcals(weakbp=False,
-                     refantignore=refantignore)
+        if restart_stage < 3:
+            hifv_priorcals(tecmaps=False)
 
-    # We need to interpolate over MW absorption in the bandpass
-    # These channels should be flagged in the calibrators.
+            # Check offline tables (updated before each run) for antenna corrections
+            # If the online tables were accessed and the correction table already exists,
+            # skip remaking.
+            make_offline_antpos_table(myvis,
+                                    data_folder="VLA_antcorr_tables",
+                                    skip_existing=True)
 
-    bandpass_with_gap_interpolation(myvis, hi_spw,
-                                    search_string="test",
-                                    task_string="hifv_testBPdcals")
+        if restart_stage < 4:
+            hifv_testBPdcals(weakbp=False,
+                            refantignore=refantignore)
 
-    hifv_flagbaddef(pipelinemode="automatic")
+            # We need to interpolate over MW absorption in the bandpass
+            # These channels should be flagged in the calibrators.
 
-    hifv_checkflag(pipelinemode="automatic")
+            bandpass_with_gap_interpolation(myvis, hi_spw,
+                                            search_string="test",
+                                            task_string="hifv_testBPdcals")
 
-    hifv_semiFinalBPdcals(weakbp=False,
-                          refantignore=refantignore)
+        if restart_stage < 5:
+            hifv_flagbaddef(pipelinemode="automatic")
 
-    hifv_checkflag(checkflagmode='semi')
+        if restart_stage < 6:
+            hifv_checkflag(pipelinemode="automatic")
 
-    hifv_semiFinalBPdcals(weakbp=False,
-                          refantignore=refantignore)
+        if restart_stage < 7:
+            hifv_semiFinalBPdcals(weakbp=False,
+                                refantignore=refantignore)
 
-    bandpass_with_gap_interpolation(myvis, hi_spw,
-                                    search_string='',
-                                    task_string='hifv_semiFinalBPdcals')
+        if restart_stage < 8:
+            hifv_checkflag(checkflagmode='semi')
 
-    hifv_solint(pipelinemode="automatic",
-                refantignore=refantignore)
+        if restart_stage < 9:
+            hifv_semiFinalBPdcals(weakbp=False,
+                                refantignore=refantignore)
 
-    hifv_fluxboot2(pipelinemode="automatic",
-                   refantignore=refantignore)
+            bandpass_with_gap_interpolation(myvis, hi_spw,
+                                            search_string='',
+                                            task_string='hifv_semiFinalBPdcals')
 
-    hifv_finalcals(weakbp=False,
-                   refantignore=refantignore)
+        if restart_stage < 10:
+            hifv_solint(pipelinemode="automatic",
+                        refantignore=refantignore)
 
-    bandpass_with_gap_interpolation(myvis, hi_spw,
-                                    search_string='final',
-                                    task_string='hifv_finalcals')
+        if restart_stage < 11:
+            hifv_fluxboot2(pipelinemode="automatic",
+                        refantignore=refantignore)
 
-    hifv_applycals(flagdetailedsum=True,
-                   gainmap=False,
-                   flagbackup=True,
-                   flagsum=True)
+        if restart_stage < 12:
+            hifv_finalcals(weakbp=False,
+                        refantignore=refantignore)
 
-    # Keep the following step in the script if cont.dat exists.
-    # Remove RFI flagging the lines in target fields.
-    if os.path.exists('cont.dat'):
-        hifv_targetflag(intents='*CALIBRATE*, *TARGET*')
-    else:
-        hifv_targetflag(intents='*CALIBRATE*')
+            bandpass_with_gap_interpolation(myvis, hi_spw,
+                                            search_string='final',
+                                            task_string='hifv_finalcals')
 
-    hifv_statwt(pipelinemode="automatic")
+        if restart_stage < 13:
+            hifv_applycals(flagdetailedsum=True,
+                        gainmap=False,
+                        flagbackup=True,
+                        flagsum=True)
 
-    hifv_plotsummary(pipelinemode="automatic")
+        # Keep the following step in the script if cont.dat exists.
+        # Remove RFI flagging the lines in target fields.
+        if restart_stage < 14:
+            if os.path.exists('cont.dat'):
+                hifv_targetflag(intents='*CALIBRATE*, *TARGET*')
+            else:
+                hifv_targetflag(intents='*CALIBRATE*')
 
-    # TODO: Choose a representative target field to image?
-    hif_makeimlist(nchan=-1,
-                   calmaxpix=300,
-                   intent='PHASE,BANDPASS')
+        if restart_stage < 15:
+            hifv_statwt(pipelinemode="automatic")
 
-    hif_makeimages(tlimit=2.0,
-                   hm_minbeamfrac=-999.0,
-                   hm_dogrowprune=True,
-                   hm_negativethreshold=-999.0,
-                   calcsb=False,
-                   target_list={},
-                   hm_noisethreshold=-999.0,
-                   hm_masking='none',
-                   hm_minpercentchange=-999.0,
-                   parallel='automatic',
-                   masklimit=4,
-                   hm_lownoisethreshold=-999.0,
-                   hm_growiterations=-999,
-                   cleancontranges=False,
-                   hm_sidelobethreshold=-999.0)
+        if restart_stage < 16:
+            hifv_plotsummary(pipelinemode="automatic")
 
-    # Make a folder of products for restoring the pipeline solution
-    products_folder = "products"
-    if not os.path.exists(products_folder):
-        os.mkdir(products_folder + '/')
+        if restart_stage < 17:
+            # TODO: Choose a representative target field to image?
+            hif_makeimlist(nchan=-1,
+                        calmaxpix=300,
+                        intent='PHASE,BANDPASS')
 
-    # TODO: review whether we should be including additional products
-    # here
-    hifv_exportdata(products_dir=products_folder + '/')
+        if restart_stage < 18:
+            hif_makeimages(tlimit=2.0,
+                        hm_minbeamfrac=-999.0,
+                        hm_dogrowprune=True,
+                        hm_negativethreshold=-999.0,
+                        calcsb=False,
+                        target_list={},
+                        hm_noisethreshold=-999.0,
+                        hm_masking='none',
+                        hm_minpercentchange=-999.0,
+                        parallel='automatic',
+                        masklimit=4,
+                        hm_lownoisethreshold=-999.0,
+                        hm_growiterations=-999,
+                        cleancontranges=False,
+                        hm_sidelobethreshold=-999.0)
 
-finally:
+        if restart_stage < 19:
+            # Make a folder of products for restoring the pipeline solution
+            if not os.path.exists(products_folder):
+                os.mkdir(products_folder + '/')
 
-    h_save()
+            # TODO: review whether we should be including additional products
+            # here
+            hifv_exportdata(products_dir=products_folder + '/')
+
+    finally:
+
+        h_save()
 
 # Make a new directory for the imaging outputs
 # Not required. I just like cleaning up the folder a bit.

--- a/lband_pipeline/offline_antposn_corrections.py
+++ b/lband_pipeline/offline_antposn_corrections.py
@@ -1,0 +1,227 @@
+
+'''
+Some clusters (like cedar) don't allow internet access to jobs. This
+routine below will check a pre-downloaded text file for antenna corrections that
+is updated prior to the pipeline run. `gencal` is then used to create the correction
+cal table.
+
+The reading in from a text file is adapted from Dyas Utomo and Adam Leroy
+for the EveryTHINGS project.
+'''
+
+import os
+import datetime
+from glob import glob
+
+import pipeline.infrastructure as infrastructure
+from pipeline.hif.tasks.antpos import Antpos
+import pipeline.infrastructure.casatools as casatools
+
+LOG = infrastructure.get_logger(__name__)
+
+def correct_ant_posns(vis_name, print_offsets=False,
+                      data_folder="VLA_antcorr_tables"):
+    """
+    Return antenna correction for the given measurement set.
+
+    This function is identical to the VLA pipeline version except that we
+    read from pre-downloaded files instead of querying the VLA baseline
+    website. This is to allow for corrections when running on machines without
+    internet access (e.g., clusters where job nodes have limited access).
+
+    Use "https://github.com/LocalGroup-VLALegacy/AutoDataIngest/blob/master/autodataingest/download_vlaant_corrections.py"
+    to download the corrections files.
+    """
+
+    MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN',
+              'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
+    #
+    # get start date+time of observation
+    #
+    with casatools.TableReader(vis_name+'/OBSERVATION') as table:
+        # observation = tb.open(vis_name+'/OBSERVATION')
+        time_range = table.getcol('TIME_RANGE')
+
+    MJD_start_time = time_range[0][0] / 86400
+    q1 = casatools.quanta.quantity(time_range[0][0], 's')
+    date_time = casatools.quanta.time(q1, form='ymd')
+    # date_time looks like: '2011/08/10/06:56:49'
+    [obs_year, obs_month, obs_day, obs_time_string] = date_time[0].split('/')
+    if (int(obs_year) < 2010):
+        if (print_offsets):
+            LOG.warn('Does not work for VLA observations')
+        return [1, '', []]
+    [obs_hour, obs_minute, obs_second] = obs_time_string.split(':')
+    obs_time = 10000*int(obs_year) + 100*int(obs_month) + int(obs_day) + \
+               int(obs_hour)/24.0 + int(obs_minute)/1440.0 + \
+               int(obs_second)/86400.0
+
+    #
+    # get antenna to station mappings
+    #
+    with casatools.TableReader(vis_name+'/ANTENNA') as table:
+        #observation = tb.open(vis_name+'/ANTENNA')
+        ant_names = table.getcol('NAME')
+        ant_stations = table.getcol('STATION')
+    ant_num_stas = []
+    for ii in range(len(ant_names)):
+        ant_num_stas.append([int(ant_names[ii][2:]), ant_names[ii], ant_stations[ii], 0.0, 0.0, 0.0, False])
+
+    correction_lines = []
+    current_year = datetime.datetime.now().year
+    # first, see if the internet connection is possible
+    try:
+        with open(data_folder + "/" + str(current_year) + ".txt", 'r') as f:
+            lines = f.read()
+
+    except FileNotFoundError as err:
+
+        LOG.warn('Cannot find antenna position correction txt file {}'.format(err.reason))
+
+        return [2, '', []]
+
+    for year in range(2010, current_year+1):
+        with open(data_folder + "/" + str(year) + ".txt", 'r') as f:
+            lines = f.read()
+
+        html_lines = lines.split('\n')
+
+        for correction_line in html_lines:
+            if len(correction_line) and correction_line[0] != '<' and correction_line[0] != ';':
+                for month in MONTHS:
+                    if month in correction_line:
+                        correction_lines.append(str(year)+' '+correction_line)
+                        break
+
+    corrections_list = []
+    for correction_line in correction_lines:
+        correction_line_fields = correction_line.split()
+        if (len(correction_line_fields) > 9):
+            [c_year, moved_date, obs_date, put_date, put_time_str, ant, pad, Bx, By, Bz] = correction_line_fields
+            s_moved = moved_date[:3]
+            i_month = 1
+            for month in MONTHS:
+                if (moved_date.find(month) >= 0):
+                    break
+                i_month = i_month + 1
+            moved_time = 10000 * int(c_year) + 100 * i_month + \
+                         int(moved_date[3:])
+        else:
+            [c_year, obs_date, put_date, put_time_str, ant, pad, Bx, By, Bz] = correction_line_fields
+            moved_date = '     '
+            moved_time = 0
+        s_obs = obs_date[:3]
+        i_month = 1
+        for month in MONTHS:
+            if (s_obs.find(month) >= 0):
+                break
+            i_month = i_month + 1
+        obs_time_2 = 10000 * int(c_year) + 100 * i_month + int(obs_date[3:])
+        s_put = put_date[:3]
+        i_month = 1
+        for month in MONTHS:
+            if (s_put.find(month) >= 0):
+                break
+            i_month = i_month + 1
+        put_time = 10000 * int(c_year) + 100 * i_month + int(put_date[3:])
+        [put_hr, put_min] = put_time_str.split(':')
+        put_time += (int(put_hr)/24.0 + int(put_min)/1440.0)
+        corrections_list.append([c_year, moved_date, moved_time, obs_date, obs_time_2, put_date, put_time, int(ant),
+                                 pad, float(Bx), float(By), float(Bz)])
+
+    for correction_list in corrections_list:
+        [c_year, moved_date, moved_time, obs_date, obs_time_2, put_date, put_time, ant, pad, Bx, By, Bz] = correction_list
+        ant_ind = -1
+        for ii in range(len(ant_num_stas)):
+            ant_num_sta = ant_num_stas[ii]
+            if (ant == ant_num_sta[0]):
+                ant_ind = ii
+                break
+        if ((ant_ind == -1) or (ant_num_sta[6])):
+            # the antenna in this correction isn't in the observation, or is done,
+            # so skip it
+            pass
+        ant_num_sta = ant_num_stas[ant_ind]
+        if (moved_time):
+            # the antenna moved
+            if (moved_time > obs_time):
+                # we are done considering this antenna
+                ant_num_sta[6] = True
+            else:
+                # otherwise, it moved, so the offsets should be reset
+                ant_num_sta[3] = 0.0
+                ant_num_sta[4] = 0.0
+                ant_num_sta[5] = 0.0
+        if ((put_time > obs_time) and (not ant_num_sta[6]) and (pad == ant_num_sta[2])):
+            # it's the right antenna/pad; add the offsets to those already accumulated
+            ant_num_sta[3] += Bx
+            ant_num_sta[4] += By
+            ant_num_sta[5] += Bz
+
+    ants = []
+    parms = []
+    for ii in range(len(ant_num_stas)):
+        ant_num_sta = ant_num_stas[ii]
+        if ((ant_num_sta[3] != 0.0) or (ant_num_sta[4] != 0.0) or (ant_num_sta[3] != 0.0)):
+            if (print_offsets):
+                LOG.info("offsets for antenna %4s : %8.5f  %8.5f  %8.5f" %
+                         (ant_num_sta[1], ant_num_sta[3], ant_num_sta[4], ant_num_sta[5]))
+            ants.append(ant_num_sta[1])
+            parms.append(ant_num_sta[3])
+            parms.append(ant_num_sta[4])
+            parms.append(ant_num_sta[5])
+    if ((len(parms) == 0) and print_offsets):
+        LOG.info("No offsets found for this MS")
+    ant_string = ','.join(["%s" % ii for ii in ants])
+    return [0, ant_string, parms]
+
+
+def make_offline_antpos_table(vis_name, data_folder="VLA_antcorr_tables",
+                              skip_existing=False):
+    '''
+    Run `gencal` to create the baseline correction table using pre-downloaded
+    correction files instead of querying the website.
+
+    Reproduces the expected table name made by `hifv_priorcals`
+
+    Use "https://github.com/LocalGroup-VLALegacy/AutoDataIngest/blob/master/autodataingest/download_vlaant_corrections.py"
+    to download the corrections files.
+
+    '''
+
+    from tasks import gencal
+
+    antenna_offsets = correct_ant_posns(vis_name, data_folder=data_folder)
+
+    # Search for an existing antpos file:
+    priorcal_tbls = glob("{0}.hifv_priorcals.*".format(vis_name))
+
+    antpos_tblname = None
+    for tbl in priorcal_tbls:
+        if 'ants' in tbl:
+            if skip_existing:
+                LOG.info("Antenna offset table already exists. Skipping.")
+                return
+
+            antpos_tblname = tbl
+            os.system("rm -r {0}".format(tbl))
+
+    # Come up with the right name for the pipeline when it doesn't already exist
+    if antpos_tblname is None:
+        priorcal_tbls.sort()
+
+        template_table = priorcal_tbls[-1]
+
+        prefix = "_".join(template_table.split("_")[:2])
+
+        antpos_tblname = "{0}_{1}.ants.tbl".format(prefix, len(priorcal_tbls) + 2)
+
+    if (antenna_offsets[0] == 0):
+        gencal(vis=vis_name,
+               caltable=antpos_tblname,
+               caltype='antpos',
+               antenna=antenna_offsets[1],
+               parameter=antenna_offsets[2])
+
+    else:
+        LOG.info("No antenna offsets found for this MS")


### PR DESCRIPTION
Some clusters won't allow internet access on the job nodes. To include baseline corrections, I've added a [function](https://github.com/LocalGroup-VLALegacy/AutoDataIngest/blob/master/autodataingest/download_vlaant_corrections.py) in AutoDataIngest to update the correction tables into txt files, and another function that reads in those corrections from the txt files. The latter is otherwise identical to the function used in the VLA pipeline.

Also added restarting for our continuum and line pipeline scripts when the job is disrupted or runs out of time.