### PR TITLE
Moving pipeline to casa 6.4

### DIFF
--- a/lband_pipeline/continuum_pipeline.py
+++ b/lband_pipeline/continuum_pipeline.py
@@ -224,7 +224,8 @@ if not skip_pipeline:
         if restart_stage <= 6:
             hifv_testBPdcals(pipelinemode="automatic",
                              weakbp=False,
-                             refantignore=refantignore)
+                             refantignore=refantignore,
+                             doflagundernspwlimit=True)
 
         if restart_stage <= 7:
             hifv_checkflag(checkflagmode='bpd-vla')

--- a/lband_pipeline/continuum_pipeline.py
+++ b/lband_pipeline/continuum_pipeline.py
@@ -94,6 +94,7 @@ if len(context_files) > 0:
                  'hifv_flagdata',
                  'hifv_vlasetjy',
                  'hifv_priorcals',
+                 'hifv_syspower',
                  'hifv_testBPdcals',
                  'hifv_checkflag',
                  'hifv_semiFinalBPdcals',
@@ -103,7 +104,6 @@ if len(context_files) > 0:
                  'hifv_finalcals',
                  'hifv_applycals',
                  'hifv_checkflag',
-                 'hifv_targetflag',
                  'hifv_statwt',
                  'hifv_plotsummary',
                  'hif_makeimlist',
@@ -219,38 +219,37 @@ if not skip_pipeline:
                                      skip_existing=True)
 
         if restart_stage <= 5:
+            hifv_syspower(pipelinemode="automatic")
+
+        if restart_stage <= 6:
             hifv_testBPdcals(pipelinemode="automatic",
                              weakbp=False,
                              refantignore=refantignore)
 
-        if restart_stage <= 6:
+        if restart_stage <= 7:
             hifv_checkflag(checkflagmode='bpd-vla')
             h_save()
 
-        if restart_stage <= 7:
+        if restart_stage <= 8:
             hifv_semiFinalBPdcals(pipelinemode="automatic",
                                   weakbp=False,
                                   refantignore=refantignore)
 
-        if restart_stage <= 8:
+        if restart_stage <= 9:
             hifv_checkflag(checkflagmode='allcals-vla')
             h_save()
 
-        # if restart_stage <= 9:
-        #     hifv_semiFinalBPdcals(weakbp=False,
-        #                           refantignore=refantignore)
-
-        if restart_stage <= 9:
+        if restart_stage <= 10:
             hifv_solint(pipelinemode="automatic",
                         refantignore=refantignore)
 
-        if restart_stage <= 10:
+        if restart_stage <= 11:
             hifv_fluxboot(pipelinemode="automatic",
                           fitorder=2,
                           refantignore=refantignore)
             h_save()
 
-        if restart_stage <= 11:
+        if restart_stage <= 12:
             # Don't grow flags at this step. We have long slews to our pol cals
             # and growtime=50 can wipe out the whole scan!
             # flagdata(vis=myvis, mode='extend', extendpols=True, action='apply',
@@ -264,7 +263,7 @@ if not skip_pipeline:
                            weakbp=False,
                            refantignore=refantignore)
 
-        if restart_stage <= 12:
+        if restart_stage <= 13:
             hifv_applycals(pipelinemode="automatic",
                            flagdetailedsum=True,
                            gainmap=False,
@@ -272,13 +271,13 @@ if not skip_pipeline:
                            flagsum=True)
             h_save()
 
-        if restart_stage <= 13:
+        if restart_stage <= 14:
             hifv_checkflag(checkflagmode='target-vla')
             h_save()
 
-        if restart_stage <= 14:
-            hifv_targetflag(intents='*TARGET*')
-            h_save()
+        # if restart_stage <= 14:
+        #     hifv_targetflag(intents='*TARGET*')
+        #     h_save()
 
         if restart_stage <= 15:
             hifv_statwt(datacolumn='corrected')
@@ -308,8 +307,6 @@ if not skip_pipeline:
             if not os.path.exists(products_folder):
                 os.mkdir(products_folder + '/')
 
-            # TODO: review whether we should be including additional products
-            # here
             hifv_exportdata(products_dir=products_folder + '/',
                             gainmap=False,
                             exportmses=False,

--- a/lband_pipeline/line_pipeline.py
+++ b/lband_pipeline/line_pipeline.py
@@ -258,7 +258,8 @@ if not skip_pipeline:
         if restart_stage <= 5:
             hifv_testBPdcals(pipelinemode="automatic",
                              weakbp=False,
-                             refantignore=refantignore)
+                             refantignore=refantignore,
+                             doflagundernspwlimit=True)
             h_save()
 
             # We need to interpolate over MW absorption in the bandpass

--- a/lband_pipeline/line_pipeline.py
+++ b/lband_pipeline/line_pipeline.py
@@ -112,6 +112,7 @@ if len(context_files) > 0:
                  'hifv_flagdata',
                  'hifv_vlasetjy',
                  'hifv_priorcals',
+                 'hifv_syspower',
                  'hifv_testBPdcals',
                  'hifv_checkflag',
                  'hifv_semiFinalBPdcals',
@@ -121,8 +122,6 @@ if len(context_files) > 0:
                  'hifv_finalcals',
                  'hifv_applycals',
                  'hifv_checkflag',
-                #  'hifv_targetflag',
-                #  'hifv_statwt',
                  'hifv_plotsummary',
                  'hif_makeimlist',
                  'hif_makeimages',
@@ -254,6 +253,9 @@ if not skip_pipeline:
                                       skip_existing=True)
 
         if restart_stage <= 4:
+            hifv_syspower(pipelinemode="automatic")
+
+        if restart_stage <= 5:
             hifv_testBPdcals(pipelinemode="automatic",
                              weakbp=False,
                              refantignore=refantignore)
@@ -266,30 +268,30 @@ if not skip_pipeline:
                                             search_string="test",
                                             task_string="hifv_testBPdcals")
 
-        if restart_stage <= 5:
+        if restart_stage <= 6:
             hifv_checkflag(checkflagmode='bpd-vla')
             h_save()
 
-        if restart_stage <= 6:
+        if restart_stage <= 7:
             hifv_semiFinalBPdcals(pipelinemode="automatic",
                                   weakbp=False,
                                   refantignore=refantignore)
 
-        if restart_stage <= 7:
+        if restart_stage <= 8:
             hifv_checkflag(checkflagmode='allcals-vla')
             h_save()
 
-        if restart_stage <= 8:
+        if restart_stage <= 9:
             hifv_solint(pipelinemode="automatic",
                         refantignore=refantignore)
 
-        if restart_stage <= 9:
+        if restart_stage <= 10:
             hifv_fluxboot(pipelinemode="automatic",
                           fitorder=2,
                           refantignore=refantignore)
             h_save()
 
-        if restart_stage <= 10:
+        if restart_stage <= 11:
             hifv_finalcals(pipelinemode="automatic",
                            weakbp=False,
                            refantignore=refantignore)
@@ -298,7 +300,7 @@ if not skip_pipeline:
                                             search_string='final',
                                             task_string='hifv_finalcals')
 
-        if restart_stage <= 11:
+        if restart_stage <= 12:
             hifv_applycals(pipelinemode="automatic",
                            flagdetailedsum=True,
                            gainmap=False,
@@ -308,7 +310,7 @@ if not skip_pipeline:
 
         # Keep the following step in the script if cont.dat exists.
         # Remove RFI flagging the lines in target fields.
-        if restart_stage <= 12:
+        if restart_stage <= 13:
             if os.path.exists('cont.dat'):
                 hifv_checkflag(checkflagmode='target-vla')
             else:
@@ -326,10 +328,10 @@ if not skip_pipeline:
         # if restart_stage <= 14:
         #     hifv_statwt(datacolumn='corrected')
 
-        if restart_stage <= 13:
+        if restart_stage <= 14:
             hifv_plotsummary(pipelinemode="automatic")
 
-        if restart_stage <= 14:
+        if restart_stage <= 15:
             hif_makeimlist(nchan=-1,
                            calcsb=False,
                            intent='PHASE,BANDPASS',
@@ -340,17 +342,15 @@ if not skip_pipeline:
                            specmode='mfs',
                            clearlist=True)
 
-        if restart_stage <= 15:
+        if restart_stage <= 16:
             hif_makeimages(hm_masking='centralregion')
             h_save()
 
-        if restart_stage <= 16:
+        if restart_stage <= 17:
             # Make a folder of products for restoring the pipeline solution
             if not os.path.exists(products_folder):
                 os.mkdir(products_folder + '/')
 
-            # TODO: review whether we should be including additional products
-            # here
             hifv_exportdata(products_dir=products_folder + '/',
                             gainmap=False,
                             exportmses=False,


### PR DESCRIPTION
Local tests with our IC10 D config test block checked out.

The biggest change here is enabling `doflagundernspwlimit=True` for `hifv_testBPdcals` as this will _likely_ avoid whole antennas being flagged as a bad deformatter when it's really just the lovely L-band RFI environment.